### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2020, Project contributors
+Copyright (c) 2019-2022, Project contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x",
-    "typescript": "~4.0.2"
+    "@hapi/lab": "^25.0.1",
+    "@types/node": "^17.0.36",
+    "typescript": "~4.7.2"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -Y",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let File;
+
+    before(async () => {
+
+        File = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(File)).to.equal([
+            'default',
+            'uniqueFilename'
+        ]);
+    });
+});


### PR DESCRIPTION
 - Test on node v14+.
 - Update to node v18-compatible versions of hapi modules, update typescript and node types.
 - Ensure all exports are available when used as ESM module.

If this looks good, this will go out as file v3.