### PR TITLE
Use HTTPS for repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hapi/file",
   "description": "General purpose file utilities",
   "version": "3.0.0",
-  "repository": "git://github.com/hapijs/file",
+  "repository": "https://github.com/hapijs/file",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary\n- update the package repository URL to use HTTPS instead of the legacy git protocol\n\n## Validation\n- git diff --check\n- node -e 'JSON.parse(require("fs").readFileSync("package.json","utf8"))'